### PR TITLE
Removed check for odex files

### DIFF
--- a/prebuilt/common/bin/backuptool.functions
+++ b/prebuilt/common/bin/backuptool.functions
@@ -11,13 +11,8 @@ backup_file() {
   if [ -e "$1" ]; then
     local F=`basename "$1"`
     local D=`dirname "$1"`
-    # dont backup any apps that have odex files, they are useless
-    if ( echo "$F" | grep -q "\.apk$" ) && [ -e `echo "$1" | sed -e 's/\.apk$/\.odex/'` ]; then
-      echo "Skipping odexed apk $1";
-    else
       mkdir -p "$C/$D"
       cp -p $1 "$C/$D/$F"
-    fi
   fi
 }
 


### PR DESCRIPTION
All of the gapps packages contain odex files, to remain ART compatible.
