### PR TITLE
Update apns-conf.xml

### DIFF
--- a/prebuilt/common/etc/apns-conf.xml
+++ b/prebuilt/common/etc/apns-conf.xml
@@ -525,8 +525,12 @@
   <apn carrier="MMS Nova" mcc="274" mnc="11" apn="mms.nova.is" mmsc="http://mmsc.nova.is" mmsproxy="10.10.2.60" mmsport="8080" type="mms" />
   <apn carrier="Net Nova" mcc="274" mnc="11" apn="net.nova.is" type="default,supl" />
   <apn carrier="Tal" mcc="274" mnc="12" apn="internet.tal.is" mmsc="http://mms.tal.is/servlets/mms" mmsproxy="213.167.138.210" mmsport="8080" type="default,supl,mms" />
-  <apn carrier="Vodafone AL" mcc="276" mnc="02" apn="Twa" type="default,supl" />
+  <apn carrier="AMC" mcc="276" mnc="01" apn="internet.amc" type="default,supl" />
+  <apn carrier="AMC MMS" mcc="276" mnc="01" apn="mms" mmsc="http://195.167.65.220:8002" mmsproxy="10.10.10.20" mmsport="8080" type="mms" />
+  <apn carrier="Vodafone AL" mcc="276" mnc="02" apn="vodafoneweb" type="default,supl" />
   <apn carrier="Vodafone AL MMS" mcc="276" mnc="02" apn="vfalmms" mmsc="http://mmsc.vodafone.al" mmsproxy="10.0.9.2" mmsport="8080" type="mms" />
+  <apn carrier="Eagle Mobile" mcc="276" mnc="03" apn="internet" type="default,supl" />
+  <apn carrier="Plus" mcc="276" mnc="04" apn="plusweb" type="default,supl" />
   <apn carrier="Cytamobile MMS" mcc="280" mnc="01" apn="cytamobile" user="user" password="pass" mmsc="http://mmsc.cyta.com.cy" mmsproxy="212.031.096.161" mmsport="9201" type="mms" />
   <apn carrier="Cytamobile" mcc="280" mnc="01" apn="internet" type="default,supl" />
   <apn carrier="MTN CY" mcc="280" mnc="10" apn="internet" user="wap" password="wap" type="default,supl" />


### PR DESCRIPTION
Hello,
I have noticed that cm doesn't have correct values for Vodafone Albania and is missing three other operators, i decided to contribute with this settings (line 528 to 533) and their references:
Vodafone AL: http://www.vodafone.al/vodafone/Automatic_Manual_2581_2.php
AMC: http://www.amc.al/al/samsung-pjesa-i-1705/samsung-galaxy-s4-1717
Eagle Mobile:http://www.apn-settings.info/?p=19
Plus Communications:https://www.plus.al/en/individuals-internet-plus-internet
