### PR TITLE
init: allow running sysinit if not encrypted

### DIFF
--- a/prebuilt/common/etc/init.local.rc
+++ b/prebuilt/common/etc/init.local.rc
@@ -16,6 +16,9 @@ on post-fs-data
     # Run sysinit
     start sysinit
 
+on property:ro.crypto.state=unencrypted
+    srart sysinit
+
 on boot
     # interactive governor
     chown system system /sys/devices/system/cpu/cpufreq/interactive/timer_rate

--- a/prebuilt/common/etc/init.local.rc
+++ b/prebuilt/common/etc/init.local.rc
@@ -17,7 +17,7 @@ on post-fs-data
     start sysinit
 
 on property:ro.crypto.state=unencrypted
-    srart sysinit
+    start sysinit
 
 on boot
     # interactive governor


### PR DESCRIPTION
Currently sysinit is called on post-fs-data event which is triggered on property vold.decrypt=trigger_post_fs_data in /init.rc. If the /data partition is not encrypted, post-fs-data will never be triggered and, as a result, user init scripts from /etc/init.d/ and /data/local/userinit.sh will never be run.

This fix enables the init scripts for not encrypted devices.

Signed-off-by: Denis Shulyaka Shulyaka@gmail.com
